### PR TITLE
Allow multiple urls per split, and office_events task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,7 @@ dmypy.json
 #spotty configured file
 spotty.yaml
 
-embeddings/
+./embeddings/
+./tasks/
 lightning_logs/
-tasks/
 wandb/

--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,6 @@ dmypy.json
 #spotty configured file
 spotty.yaml
 
-./embeddings/
 ./tasks/
 lightning_logs/
 wandb/

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -27,12 +27,12 @@ task_config = {
     "prediction_type": "multilabel",
     "download_urls": [
         {
-            "name": "train",
+            "split": "train",
             "url": "https://archive.org/download/dcase2016_task2_train_dev/dcase2016_task2_train_dev.zip",  # noqa: E501
             "md5": "4e1b5e8887159193e8624dec801eb9e7",
         },
         {
-            "name": "test",
+            "split": "test",
             "url": "https://archive.org/download/dcase2016_task2_test_public/dcase2016_task2_test_public.zip",  # noqa: E501
             "md5": "ac98768b39a08fc0c6c2ddd15a981dd7",
         },
@@ -41,12 +41,12 @@ task_config = {
     "small": {
         "download_urls": [
             {
-                "name": "train",
+                "split": "train",
                 "url": "https://github.com/neuralaudio/hear2021-open-tasks-downsampled/raw/main/dcase2016_task2_train_dev-small.zip",  # noqa: E501
                 "md5": "aa9b43c40e9d496163caab83becf972e",
             },
             {
-                "name": "test",
+                "split": "test",
                 "url": "https://github.com/neuralaudio/hear2021-open-tasks-downsampled/raw/main/dcase2016_task2_test_public-small.zip",  # noqa: E501
                 "md5": "14539d85dec03cb7ac75eb62dd1dd21e",
             },

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -93,7 +93,7 @@ class ExtractMetadata(pipeline.ExtractMetadata):
         "test": "dcase2016_task2_test_public/",
     }
 
-    def get_split_metadata(self, split: str) -> pd.DataFrame:
+    def get_requires_metadata(self, split: str) -> pd.DataFrame:
         logger.info(f"Preparing metadata for {split}")
 
         split_path = (
@@ -125,7 +125,7 @@ class ExtractMetadata(pipeline.ExtractMetadata):
 
             metadatas.append(metadata)
 
-        return pd.concat(metadatas)
+        return pd.concat(metadatas).reset_index(drop=True)
 
 
 def main(

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -84,7 +84,7 @@ class ExtractMetadata(pipeline.ExtractMetadata):
         filename = f"{item}.wav"
         return audio_path.joinpath(filename)
 
-    def get_split_metadata(self, split: str) -> pd.DataFrame:
+    def get_requires_metadata(self, split: str) -> pd.DataFrame:
         logger.info(f"Preparing metadata for {split}")
 
         # Loads and prepares the metadata for a specific split

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -23,17 +23,17 @@ task_config = {
     "prediction_type": "multiclass",
     "download_urls": [
         {
-            "name": "train",
+            "split": "train",
             "url": "http://download.magenta.tensorflow.org/datasets/nsynth/nsynth-train.jsonwav.tar.gz",  # noqa: E501
             "md5": "fde6665a93865503ba598b9fac388660",
         },
         {
-            "name": "valid",
+            "split": "valid",
             "url": "http://download.magenta.tensorflow.org/datasets/nsynth/nsynth-valid.jsonwav.tar.gz",  # noqa: E501
             "md5": "87e94a00a19b6dbc99cf6d4c0c0cae87",
         },
         {
-            "name": "test",
+            "split": "test",
             "url": "http://download.magenta.tensorflow.org/datasets/nsynth/nsynth-test.jsonwav.tar.gz",  # noqa: E501
             "md5": "5e6f8719bf7e16ad0a00d518b78af77d",
         },
@@ -44,17 +44,17 @@ task_config = {
     "small": {
         "download_urls": [
             {
-                "name": "train",
+                "split": "train",
                 "url": "https://github.com/neuralaudio/hear2021-open-tasks-downsampled/raw/main/nsynth-train-small.zip",  # noqa: E501
                 "md5": "c17070e4798655d8bea1231506479ba8",
             },
             {
-                "name": "valid",
+                "split": "valid",
                 "url": "https://github.com/neuralaudio/hear2021-open-tasks-downsampled/raw/main/nsynth-valid-small.zip",  # noqa: E501
                 "md5": "e36722262497977f6b945bb06ab0969d",
             },
             {
-                "name": "test",
+                "split": "test",
                 "url": "https://github.com/neuralaudio/hear2021-open-tasks-downsampled/raw/main/nsynth-test-small.zip",  # noqa: E501
                 "md5": "9a98e869ed4add8ba9ebb0d7c22becca",
             },

--- a/heareval/tasks/office_events.py
+++ b/heareval/tasks/office_events.py
@@ -69,7 +69,7 @@ task_config = {
 
 class ExtractMetadata(pipeline.ExtractMetadata):
     train_dev = luigi.TaskParameter()
-    train_eval= luigi.TaskParameter()
+    train_eval = luigi.TaskParameter()
 
     def requires(self):
         return {"train_eval": self.train_eval, "train_dev": self.train_dev}
@@ -102,34 +102,33 @@ class ExtractMetadata(pipeline.ExtractMetadata):
 
         assert requires_key.startswith("train_")
 
-        requires_path = (
-            Path(self.requires()[requires_key].workdir)
-            .joinpath(self.requires_key_to_path_str[requires_key])
+        requires_path = Path(self.requires()[requires_key].workdir).joinpath(
+            self.requires_key_to_path_str[requires_key]
         )
 
         metadatas = []
         for annotation_file in requires_path.glob("annotation/*.txt"):
             metadata = pd.read_csv(
-                    annotation_file,
-                    sep="\t",
-                    header=None,
-                    names=["start", "end", "label"],
+                annotation_file,
+                sep="\t",
+                header=None,
+                names=["start", "end", "label"],
             )
             # Convert start and end times to milliseconds
             metadata["start"] *= 1000
             metadata["end"] *= 1000
             sound_file = (
-                    str(annotation_file)
-                    .replace("annotation", "sound")
-                    .replace(".txt", ".wav")
+                str(annotation_file)
+                .replace("annotation", "sound")
+                .replace(".txt", ".wav")
             )
             metadata = metadata.assign(
-                    relpath=sound_file,
-                    slug=lambda df: df.relpath.apply(self.slugify_file_name),
-                    subsample_key=self.get_subsample_key,
-                    split=lambda df: "train",
-                    split_key=self.get_split_key,
-                )
+                relpath=sound_file,
+                slug=lambda df: df.relpath.apply(self.slugify_file_name),
+                subsample_key=self.get_subsample_key,
+                split=lambda df: "train",
+                split_key=self.get_split_key,
+            )
 
             metadatas.append(metadata)
 

--- a/heareval/tasks/office_events.py
+++ b/heareval/tasks/office_events.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Pre-processing pipeline for DCASE 2016 task 2 task (sound event
+detection).
+
+The HEAR 2021 variation of DCASE 2016 Task 2 is that we ignore the
+monophonic training data. We mix the dev and eval data, and
+re-partition ourselves, to reduce variance between the partitions.
+
+We also allow training data outside this task.
+"""
+
+import logging
+from pathlib import Path
+from typing import List
+
+import luigi
+import pandas as pd
+from slugify import slugify
+
+import heareval.tasks.pipeline as pipeline
+
+logger = logging.getLogger("luigi-interface")
+
+task_config = {
+    "task_name": "office_events",
+    "version": "hear2021",
+    "embedding_type": "event",
+    "prediction_type": "multilabel",
+    "download_urls": [
+        {
+            "split": "train",
+            "name": "dev",
+            # "url": "https://archive.org/download/dcase2016_task2_train_dev/dcase2016_task2_train_dev.zip",  # noqa: E501
+            "url": "https://www.dropbox.com/s/wpzzo7k1p3vs1q9/dcase2016_task2_train_dev.zip",  # noqa: E501
+            "md5": "4e1b5e8887159193e8624dec801eb9e7",
+        },
+        {
+            "split": "train",
+            "name": "eval",
+            # "url": "https://archive.org/download/dcase2016_task2_test_public/dcase2016_task2_test_public.zip",  # noqa: E501
+            "url": "https://www.dropbox.com/s/w5psvsyr651pc1f/dcase2016_task2_test_public.zip",  # noqa: E501
+            "md5": "ac98768b39a08fc0c6c2ddd15a981dd7",
+        },
+    ],
+    "sample_duration": 120.0,
+    "small": {
+        "download_urls": [
+            {
+                "split": "train",
+                "name": "dev",
+                "url": "https://github.com/neuralaudio/hear2021-open-tasks-downsampled/raw/main/dcase2016_task2_train_dev-small.zip",  # noqa: E501
+                "md5": "aa9b43c40e9d496163caab83becf972e",
+            },
+            {
+                "split": "train",
+                "name": "eval",
+                "url": "https://github.com/neuralaudio/hear2021-open-tasks-downsampled/raw/main/dcase2016_task2_test_public-small.zip",  # noqa: E501
+                "md5": "14539d85dec03cb7ac75eb62dd1dd21e",
+            },
+        ],
+        "version": "hear2021-small",
+    },
+    # DCASE2016 task 2 used the segment-based total error rate as
+    # their main score and then the onset only event based F1 as
+    # their secondary score.
+    # However, we announced that onset F1 would be our primary score.
+    "evaluation": ["event_onset_200ms_fms", "segment_1s_er"],
+}
+
+
+class ExtractMetadata(pipeline.ExtractMetadata):
+    train = luigi.TaskParameter()
+    test = luigi.TaskParameter()
+
+    def requires(self):
+        return {"train": self.train, "test": self.test}
+
+    @staticmethod
+    def slugify_file_name(relative_path: str):
+        """
+        Overriding slugify method for dcase files. Normally, slugify will remove
+        extra hyphens(-) and this will create ambiguity for positive and negative
+        decibles in dcase file names as they also have decible information in the
+        file names (example 6 and -6 will be slugified to being 6, which is not
+        expected)
+        """
+        slug_text = str(Path(relative_path).stem)
+        # Replace all the '-' to '_negative_'
+        slug_text = slug_text.replace("-", "_negative_")
+        return f"{slugify(slug_text)}"
+
+    """
+    DCASE 2016 uses funny pathing, so we just hardcode the desired
+    (paths)
+    """
+    train_name_to_path_str = {
+        "dev": "dev/dcase2016_task2_train_dev/dcase2016_task2_dev/",
+        "eval": "eval/dcase2016_task2_test_public/",
+    }
+
+    def get_split_metadata(self, split: str) -> pd.DataFrame:
+        logger.info(f"Preparing metadata for {split}")
+
+        assert split == "train"
+
+        metadatas = []
+        for name in train_name_to_path_str:
+            split_path = (
+                Path(self.requires()[split].workdir)
+                .joinpath(split)
+                .joinpath(self.split_to_path_str[name])
+            )
+
+            for annotation_file in split_path.glob("annotation/*.txt"):
+                metadata = pd.read_csv(
+                    annotation_file,
+                    sep="\t",
+                    header=None,
+                    names=["start", "end", "label"],
+                )
+                # Convert start and end times to milliseconds
+                metadata["start"] *= 1000
+                metadata["end"] *= 1000
+                sound_file = (
+                    str(annotation_file)
+                    .replace("annotation", "sound")
+                    .replace(".txt", ".wav")
+                )
+                metadata = metadata.assign(
+                    relpath=sound_file,
+                    slug=lambda df: df.relpath.apply(self.slugify_file_name),
+                    subsample_key=self.get_subsample_key,
+                    split=lambda df: split,
+                    split_key=self.get_split_key,
+                )
+
+                metadatas.append(metadata)
+
+        return pd.concat(metadatas)
+
+
+def main(
+    sample_rates: List[int],
+    tmp_dir: str,
+    tasks_dir: str,
+    small: bool = False,
+):
+    if small:
+        task_config.update(dict(task_config["small"]))  # type: ignore
+    task_config.update({"tmp_dir": tmp_dir})
+
+    # Build the dataset pipeline with the custom metadata configuration task
+    download_tasks = pipeline.get_download_and_extract_tasks(task_config)
+
+    configure_metadata = ExtractMetadata(
+        outfile="process_metadata.csv", task_config=task_config, **download_tasks
+    )
+    final_task = pipeline.FinalizeCorpus(
+        sample_rates=sample_rates,
+        tasks_dir=tasks_dir,
+        metadata=configure_metadata,
+        task_config=task_config,
+    )
+    return final_task

--- a/heareval/tasks/office_events.py
+++ b/heareval/tasks/office_events.py
@@ -32,14 +32,12 @@ task_config = {
             "split": "train",
             "name": "dev",
             "url": "https://archive.org/download/dcase2016_task2_train_dev/dcase2016_task2_train_dev.zip",  # noqa: E501
-            # "url": "https://www.dropbox.com/s/wpzzo7k1p3vs1q9/dcase2016_task2_train_dev.zip",  # noqa: E501
             "md5": "4e1b5e8887159193e8624dec801eb9e7",
         },
         {
             "split": "train",
             "name": "eval",
             "url": "https://archive.org/download/dcase2016_task2_test_public/dcase2016_task2_test_public.zip",  # noqa: E501
-            # "url": "https://www.dropbox.com/s/w5psvsyr651pc1f/dcase2016_task2_test_public.zip",  # noqa: E501
             "md5": "ac98768b39a08fc0c6c2ddd15a981dd7",
         },
     ],

--- a/heareval/tasks/office_events.py
+++ b/heareval/tasks/office_events.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
-Pre-processing pipeline for DCASE 2016 task 2 task (sound event
-detection).
+Task adapted from DCASE 2016 task 2: office sound event detection.
 
 The HEAR 2021 variation of DCASE 2016 Task 2 is that we ignore the
 monophonic training data. We mix the dev and eval data, and

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -435,6 +435,7 @@ class SubsampleSplit(WorkTask):
 
         # Since event detection metadata will have duplicates, we de-dup
         # TODO: We might consider different choices of subset
+        # FIXME
         metadata = (
             metadata.sort_values(by="subsample_key")
             # Drop duplicates as the subsample key is expected to be unique

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -78,9 +78,7 @@ class ExtractArchive(WorkTask):
         visibility=luigi.parameter.ParameterVisibility.PRIVATE
     )
     # Outdir is the sub dir inside the workdir to extract the file.
-    # If set to None the file is extracted in the workdir without any
-    # subdir
-    outdir = luigi.Parameter(default=None)
+    outdir = luigi.Parameter()
 
     def requires(self):
         return {"download": self.download}

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -256,7 +256,7 @@ class ExtractMetadata(WorkTask):
         return process_metadata
 
     def get_requires_metadata(self, requires_key: str) -> pd.DataFrame:
-        raise NotImplementError("Deriving classes need to implement this")
+        raise NotImplementedError("Deriving classes need to implement this")
 
     def split_train_test_val(self, metadata: pd.DataFrame):
         """

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -6,7 +6,7 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Set, Union
 from urllib.parse import urlparse
 
 import luigi
@@ -98,14 +98,14 @@ class ExtractArchive(WorkTask):
         self.mark_complete()
 
 
-def get_download_and_extract_tasks(task_config: Dict):
+def get_download_and_extract_tasks(task_config: Dict) -> Dict[str, WorkTask]:
     """
     Iterates over the dowload urls and builds download and extract
     tasks for them
     """
 
     tasks = {}
-    outdirs = set()
+    outdirs: Set[str] = set()
     for urlobj in task_config["download_urls"]:
         split, name, url, md5 = (
             urlobj["split"],

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -107,7 +107,12 @@ def get_download_and_extract_tasks(task_config: Dict):
     tasks = {}
     outdirs = set()
     for urlobj in task_config["download_urls"]:
-        split, name, url, md5 = urlobj["split"], urlobj.get("name", None), urlobj["url"], urlobj["md5"]
+        split, name, url, md5 = (
+            urlobj["split"],
+            urlobj.get("name", None),
+            urlobj["url"],
+            urlobj["md5"],
+        )
         filename = os.path.basename(urlparse(url).path)
         if name is not None:
             outdir = f"{split}/{name}"
@@ -282,7 +287,9 @@ class ExtractMetadata(WorkTask):
 
         # Depending on whether valid and test are already present, the percentage can
         # either be the predefined percentage or 0
-        validation_percentage = VALIDATION_PERCENTAGE if "valid" in splits_to_sample else 0
+        validation_percentage = (
+            VALIDATION_PERCENTAGE if "valid" in splits_to_sample else 0
+        )
         test_percentage = TEST_PERCENTAGE if "test" in splits_to_sample else 0
 
         metadata.reset_index(drop=True, inplace=True)
@@ -291,7 +298,11 @@ class ExtractMetadata(WorkTask):
         ].assign(
             split=lambda df: df["split_key"].apply(
                 # Use the which set to split the train into the required splits
-                lambda split_key: which_set(split_key, validation_percentage=validation_percentage, test_percentage=test_percentage)
+                lambda split_key: which_set(
+                    split_key,
+                    validation_percentage=validation_percentage,
+                    test_percentage=test_percentage,
+                )
             )
         )
         return metadata

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -282,8 +282,8 @@ class ExtractMetadata(WorkTask):
 
         # Depending on whether valid and test are already present, the percentage can
         # either be the predefined percentage or 0
-        valid_perc = VALIDATION_PERCENTAGE if "valid" in splits_to_sample else 0
-        test_perc = TEST_PERCENTAGE if "test" in splits_to_sample else 0
+        validation_percentage = VALIDATION_PERCENTAGE if "valid" in splits_to_sample else 0
+        test_percentage = TEST_PERCENTAGE if "test" in splits_to_sample else 0
 
         metadata.reset_index(drop=True, inplace=True)
         metadata[metadata["split"] == "train"] = metadata[
@@ -291,7 +291,7 @@ class ExtractMetadata(WorkTask):
         ].assign(
             split=lambda df: df["split_key"].apply(
                 # Use the which set to split the train into the required splits
-                lambda split_key: which_set(split_key, valid_perc, test_perc)
+                lambda split_key: which_set(split_key, validation_percentage=validation_percentage, test_percentage=test_percentage)
             )
         )
         return metadata

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -90,8 +90,7 @@ def run(
 ):
 
     if num_workers is None:
-        #num_workers = multiprocessing.cpu_count()
-        num_workers = 1
+        num_workers = multiprocessing.cpu_count()
         logger.info(f"Using {num_workers} workers")
 
     if sample_rate is None:

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -90,7 +90,8 @@ def run(
 ):
 
     if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
+        #num_workers = multiprocessing.cpu_count()
+        num_workers = 1
         logger.info(f"Using {num_workers} workers")
 
     if sample_rate is None:

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -11,6 +11,7 @@ import click
 
 import heareval.tasks.dcase2016_task2 as dcase2016_task2
 import heareval.tasks.nsynth_pitch as nsynth_pitch
+import heareval.tasks.office_events as office_events
 import heareval.tasks.pipeline as pipeline
 import heareval.tasks.speech_commands as speech_commands
 
@@ -35,7 +36,8 @@ tasks = {
     "speech_commands": [speech_commands],
     "nsynth_pitch": [nsynth_pitch],
     "dcase2016_task2": [dcase2016_task2],
-    "all": [speech_commands, nsynth_pitch, dcase2016_task2]
+    "office_events": [office_events],
+    "all": [speech_commands, nsynth_pitch, dcase2016_task2, office_events]
     + secret_tasks.pop("all-secrets", []),
     # Add the task config for the secrets task if the secret task config was found.
     # Not available for participants

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -26,7 +26,7 @@ from tqdm import tqdm
 
 import heareval.tasks.pipeline as pipeline
 import heareval.tasks.util.luigi as luigi_util
-from heareval.tasks import dcase2016_task2, nsynth_pitch, speech_commands
+from heareval.tasks import dcase2016_task2, nsynth_pitch, office_events, speech_commands
 
 logger = logging.getLogger("luigi-interface")
 # Currently the sampler is only allowed to run for open tasks
@@ -63,6 +63,18 @@ configs = {
     },
     "dcase2016_task2": {
         "task_config": dcase2016_task2.task_config,
+        "audio_sample_size": 4,
+        # Put two files from the dev and train split so that those splits are
+        # made
+        # dev_1_ebr_6_nec_2_poly_0.wav -> 1 train file in valid split
+        # dev_1_ebr_6_nec_3_poly_0.wav -> 1 valid file in valid split
+        "necessary_keys": [
+            "dev_1_ebr_6_nec_2_poly_0.wav",
+            "dev_1_ebr_6_nec_3_poly_0.wav",
+        ],
+    },
+    "office_events": {
+        "task_config": office_events.task_config,
         "audio_sample_size": 4,
         # Put two files from the dev and train split so that those splits are
         # made

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -205,7 +205,7 @@ class ExtractMetadata(pipeline.ExtractMetadata):
         )
         assert len(train_df.merge(validation_df, on="relpath")) == 0
 
-        return pd.concat([test_df, validation_df, train_df])
+        return pd.concat([test_df, validation_df, train_df]).reset_index(drop=True)
 
     def get_process_metadata(self) -> pd.DataFrame:
         process_metadata = self.get_split_paths()

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -29,12 +29,12 @@ task_config = {
     "prediction_type": "multiclass",
     "download_urls": [
         {
-            "name": "train",
+            "split": "train",
             "url": "http://download.tensorflow.org/data/speech_commands_v0.02.tar.gz",  # noqa: E501
             "md5": "6b74f3901214cb2c2934e98196829835",
         },
         {
-            "name": "test",
+            "split": "test",
             "url": "http://download.tensorflow.org/data/speech_commands_test_set_v0.02.tar.gz",  # noqa: E501
             "md5": "854c580ee90bff80c516491c84544e32",
         },
@@ -43,12 +43,12 @@ task_config = {
     "small": {
         "download_urls": [
             {
-                "name": "train",
+                "split": "train",
                 "url": "https://github.com/neuralaudio/hear2021-open-tasks-downsampled/raw/main/speech_commands_v0.02-small.zip",  # noqa: E501
                 "md5": "455123a88b8410d1f955c77ad331524f",
             },
             {
-                "name": "test",
+                "split": "test",
                 "url": "https://github.com/neuralaudio/hear2021-open-tasks-downsampled/raw/main/speech_commands_test_set_v0.02-small.zip",  # noqa: E501
                 "md5": "26d08374a7abd13ca2f4a4b8424f41d0",
             },

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -145,7 +145,9 @@ def filename_to_int_hash(text: str) -> int:
     return int(hash_name_hashed, 16)
 
 
-def which_set(filename_hash: int, validation_percentage: int, test_percentage: int) -> str:
+def which_set(
+    filename_hash: int, validation_percentage: int, test_percentage: int
+) -> str:
     """
     Code adapted from Google Speech Commands dataset.
 

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -117,9 +117,10 @@ def download_file(url, local_filename, expected_md5):
     From: https://stackoverflow.com/a/16696317/82733
     """
     # NOTE the stream=True parameter below
-    with requests.get(url, stream=True) as r:
+    with requests.get(url, stream=True, allow_redirects=True) as r:
         r.raise_for_status()
-        total_length = int(r.headers.get("content-length"))
+        total_length = r.headers.get("content-length")
+        total_length = int(total_length)
         with open(local_filename, "wb") as f:
             pbar = tqdm(total=total_length)
             chunk_size = 8192
@@ -131,7 +132,8 @@ def download_file(url, local_filename, expected_md5):
             pbar.close()
     assert (
         md5sum(local_filename) == expected_md5
-    ), f"Md5sum for url: {url} is: {md5sum(local_filename)}"
+    ), f"md5sum for url: {url} is: {md5sum(local_filename)}"
+    "It should be {expected_md5}"
     return local_filename
 
 
@@ -169,10 +171,10 @@ def which_set(filename_hash: int, validation_percentage: int, testing_percentage
     """
 
     percentage_hash = filename_hash % 100
-    if percentage_hash < validation_percentage:
-        result = "valid"
-    elif percentage_hash < (testing_percentage + validation_percentage):
+    if percentage_hash < test_percentage:
         result = "test"
+    elif percentage_hash < (testing_percentage + validation_percentage):
+        result = "valid"
     else:
         result = "train"
     return result

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -145,16 +145,16 @@ def filename_to_int_hash(text: str) -> int:
     return int(hash_name_hashed, 16)
 
 
-def which_set(filename_hash: int, validation_percentage: int, testing_percentage: int) -> str:
+def which_set(filename_hash: int, validation_percentage: int, test_percentage: int) -> str:
     """
     Code adapted from Google Speech Commands dataset.
 
     Determines which data split the file should belong to, based
     upon the filename int hash.
 
-    We want to keep files in the same training, validation, or testing
+    We want to keep files in the same training, validation, or test
     sets even if new ones are added over time. This makes it less
-    likely that testing samples will accidentally be reused in training
+    likely that test samples will accidentally be reused in training
     when long runs are restarted for example. To keep this stability,
     a hash of the filename is taken and used to determine which set
     it should belong to. This determination only depends on the name
@@ -164,7 +164,7 @@ def which_set(filename_hash: int, validation_percentage: int, testing_percentage
     Args:
       filename: File path of the data sample.
       validation_percentage: How much of the data set to use for validation.
-      testing_percentage: How much of the data set to use for testing.
+      test_percentage: How much of the data set to use for test.
 
     Returns:
       String, one of 'train', 'valid', or 'test'.
@@ -173,7 +173,7 @@ def which_set(filename_hash: int, validation_percentage: int, testing_percentage
     percentage_hash = filename_hash % 100
     if percentage_hash < test_percentage:
         result = "test"
-    elif percentage_hash < (testing_percentage + validation_percentage):
+    elif percentage_hash < (test_percentage + validation_percentage):
         result = "valid"
     else:
         result = "train"

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -135,7 +135,7 @@ def download_file(url, local_filename, expected_md5):
     return local_filename
 
 
-def filename_to_int_hash(text):
+def filename_to_int_hash(text: str) -> int:
     """
     Returns the sha1 hash of the text passed in.
     """
@@ -143,7 +143,7 @@ def filename_to_int_hash(text):
     return int(hash_name_hashed, 16)
 
 
-def which_set(filename_hash, validation_percentage, testing_percentage):
+def which_set(filename_hash: int, validation_percentage: int, testing_percentage: int) -> str:
     """
     Code adapted from Google Speech Commands dataset.
 


### PR DESCRIPTION
* urls can now have a split and an optional name. Name is used if there are multiple files per split.
* office_tasks is a dcase variation in which all files start in the train split.
* I also fixed some sampling and indexing bugs.