### PR TITLE
Rewriting splitting to be more precise

### DIFF
--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -23,7 +23,6 @@ from heareval.tasks.util.luigi import (
     filename_to_int_hash,
     new_basedir,
     subsample_metadata,
-    which_set,
 )
 
 SPLITS = ["train", "valid", "test"]
@@ -281,7 +280,7 @@ class ExtractMetadata(WorkTask):
             train_percentage = (
                 TRAIN_PERCENTAGE + TRAIN_PERCENTAGE * VALIDATION_PERCENTAGE / tot
             )
-            valid_percetage = 0
+            valid_percentage = 0
             test_percentage = (
                 TEST_PERCENTAGE + TEST_PERCENTAGE * VALIDATION_PERCENTAGE / tot
             )

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -271,6 +271,10 @@ class ExtractMetadata(WorkTask):
             + f"now sampled with split key are: {splits_to_sample}"
         )
 
+        train_percentage: float
+        valid_percentage: float
+        test_percentage: float
+
         # If we want a 60/20/20 split, but we already have test
         # then we want to do a 75/25/0 split so that train is still 3x validation
         if splits_to_sample == set():

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -279,7 +279,7 @@ class ExtractMetadata(WorkTask):
         # then we want to do a 75/25/0 split so that train is still 3x validation
         if splits_to_sample == set():
             return metadata
-        elif splits_to_sample == set("valid"):
+        elif splits_to_sample == set(["valid"]):
             tot = TRAIN_PERCENTAGE + TEST_PERCENTAGE
             train_percentage = (
                 TRAIN_PERCENTAGE + TRAIN_PERCENTAGE * VALIDATION_PERCENTAGE / tot
@@ -288,7 +288,7 @@ class ExtractMetadata(WorkTask):
             test_percentage = (
                 TEST_PERCENTAGE + TEST_PERCENTAGE * VALIDATION_PERCENTAGE / tot
             )
-        elif splits_to_sample == set("test"):
+        elif splits_to_sample == set(["test"]):
             tot = TRAIN_PERCENTAGE + TEST_PERCENTAGE
             train_percentage = (
                 TRAIN_PERCENTAGE + TRAIN_PERCENTAGE * TEST_PERCENTAGE / tot
@@ -298,6 +298,7 @@ class ExtractMetadata(WorkTask):
             )
             test_percentage = 0
         else:
+            assert splits_to_sample == set(["valid", "test"])
             train_percentage = TRAIN_PERCENTAGE
             valid_percentage = VALIDATION_PERCENTAGE
             test_percentage = TEST_PERCENTAGE

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -281,7 +281,7 @@ class ExtractMetadata(WorkTask):
         if splits_to_sample == set():
             return metadata
         elif splits_to_sample == set(["valid"]):
-            tot = (TRAIN_PERCENTAGE + VALID_PERCENTAGE) / 100
+            tot = (TRAIN_PERCENTAGE + VALIDATION_PERCENTAGE) / 100
             train_percentage = TRAIN_PERCENTAGE / tot
             valid_percentage = VALIDATION_PERCENTAGE / tot
             test_percentage = 0

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -275,28 +275,21 @@ class ExtractMetadata(WorkTask):
         valid_percentage: float
         test_percentage: float
 
-        # If we want a 60/20/20 split, but we already have test
-        # then we want to do a 75/25/0 split so that train is still 3x validation
+        # If we want a 60/20/20 split, but we already have test and don't
+        # to partition one, we want to do a 75/25/0 split. i.e. we
+        # keep everything summing to one and the proportions the same.
         if splits_to_sample == set():
             return metadata
         elif splits_to_sample == set(["valid"]):
-            tot = TRAIN_PERCENTAGE + TEST_PERCENTAGE
-            train_percentage = (
-                TRAIN_PERCENTAGE + TRAIN_PERCENTAGE * VALIDATION_PERCENTAGE / tot
-            )
-            valid_percentage = 0
-            test_percentage = (
-                TEST_PERCENTAGE + TEST_PERCENTAGE * VALIDATION_PERCENTAGE / tot
-            )
-        elif splits_to_sample == set(["test"]):
-            tot = TRAIN_PERCENTAGE + TEST_PERCENTAGE
-            train_percentage = (
-                TRAIN_PERCENTAGE + TRAIN_PERCENTAGE * TEST_PERCENTAGE / tot
-            )
-            valid_percentage = (
-                VALIDATION_PERCENTAGE + VALIDATION_PERCENTAGE * TEST_PERCENTAGE / tot
-            )
+            tot = (TRAIN_PERCENTAGE + VALID_PERCENTAGE) / 100
+            train_percentage = TRAIN_PERCENTAGE / tot
+            valid_percentage = VALIDATION_PERCENTAGE / tot
             test_percentage = 0
+        elif splits_to_sample == set(["test"]):
+            tot = (TRAIN_PERCENTAGE + TEST_PERCENTAGE) / 100
+            train_percentage = TRAIN_PERCENTAGE / tot
+            valid_percentage = 0
+            test_percentage = TEST_PERCENTAGE / tot
         else:
             assert splits_to_sample == set(["valid", "test"])
             train_percentage = TRAIN_PERCENTAGE

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -299,7 +299,7 @@ class ExtractMetadata(WorkTask):
             train_percentage + valid_percentage + test_percentage == 100
         ), f"{train_percentage + valid_percentage + test_percentage} != 100"
 
-        relpaths = metadata["relpath"].unique()
+        relpaths = metadata[metadata.split == "train"]["relpath"].unique()
         rng = random.Random(0)
         rng.shuffle(relpaths)
         n = len(relpaths)

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -145,43 +145,6 @@ def filename_to_int_hash(text: str) -> int:
     return int(hash_name_hashed, 16)
 
 
-def which_set(
-    filename_hash: int, validation_percentage: int, test_percentage: int
-) -> str:
-    """
-    Code adapted from Google Speech Commands dataset.
-
-    Determines which data split the file should belong to, based
-    upon the filename int hash.
-
-    We want to keep files in the same training, validation, or test
-    sets even if new ones are added over time. This makes it less
-    likely that test samples will accidentally be reused in training
-    when long runs are restarted for example. To keep this stability,
-    a hash of the filename is taken and used to determine which set
-    it should belong to. This determination only depends on the name
-    and the set proportions, so it won't change as other files are
-    added.
-
-    Args:
-      filename: File path of the data sample.
-      validation_percentage: How much of the data set to use for validation.
-      test_percentage: How much of the data set to use for test.
-
-    Returns:
-      String, one of 'train', 'valid', or 'test'.
-    """
-
-    percentage_hash = filename_hash % 100
-    if percentage_hash < test_percentage:
-        result = "test"
-    elif percentage_hash < (test_percentage + validation_percentage):
-        result = "valid"
-    else:
-        result = "train"
-    return result
-
-
 def new_basedir(filename, basedir):
     """
     Rewrite .../filename as basedir/filename


### PR DESCRIPTION
PLEASE REVIEW CAREFULLY.

Particularly for small data set, we want accurate splitting. So instead of using which_set, which sucks for small corpora, we directly sample the exact number of files we want.

I remove split_key in this PR, which is a mistake. In https://github.com/neuralaudio/hear-preprocess/pull/8 I make sure that the splitting uses a split_key, but the exact number we want.