### PR TITLE
Remove stratification

### DIFF
--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -202,25 +202,6 @@ class ExtractMetadata(WorkTask):
         assert "slug" in df, "slug column not found in the dataframe"
         return df["slug"].apply(str).apply(filename_to_int_hash)
 
-    @staticmethod
-    def get_stratify_key(df: DataFrame) -> Series:
-        """
-        CURRENTLY UNUSED.
-
-        Get the stratify key
-
-        Subsampling is stratified based on this key.
-        Since hashing is only required for ordering the samples
-        for subsampling, the stratify key should not necessarily be a hash,
-        as it is only used to group the data points before subsampling.
-        The actual subsampling is done by the split key and
-        the subsample key.
-
-        By default, the label is used for stratification
-        """
-        assert "label" in df, "label column not found in the dataframe"
-        return df["label"]
-
     def get_all_metadata(self) -> pd.DataFrame:
         """
         Return a dataframe containing all metadata for this task.

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -176,8 +176,8 @@ def subsample_metadata(metadata: pd.DataFrame, max_files: int):
 
     assert "subsample_key" in metadata.columns
     metadata = metadata.sort_values(
-        by=["subsample_key"], ascending=[True, True]
-    ).reset_index()
+        by="subsample_key", ascending=True
+    ).reset_index(drop=True)
 
     # Select the max_file number of files, from the sorted metadata
     # (by subsample key)


### PR DESCRIPTION
This doesn't work for most of our use-cases.

I also remove the split key from subsample_metadata because it's only called on a particular split