### PR TITLE
Improve determinism of all sorts

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -3,3 +3,4 @@
 rm -Rf _workdir/*/0[2-9]*
 rm -Rf _workdir/*/[1-9]*
 rm -Rf tasks/
+rm hear-2021*.tar.gz

--- a/hearpreprocess/pipeline.py
+++ b/hearpreprocess/pipeline.py
@@ -218,13 +218,18 @@ class ExtractMetadata(WorkTask):
     def get_split_key(df: pd.DataFrame) -> pd.Series:
         """
         Gets the split key.
+
+            We use the slug because, unlike the relpath, it doesn't
+            a possibly variable base directory. ExtractMetadata.run()
+        ensures that slugs are unique.
+
         A file should only be in one split, i.e. we shouldn't spread
         file events across splits. This is the default behavior.
         For some corpora, we might want to be even more restrictive:
         * An instrument cannot be split.
         * A speaker cannot be split.
         """
-        return df["relpath"]
+        return df["slug"]
 
     def split_train_test_val(self, metadata: pd.DataFrame):
         """
@@ -235,6 +240,22 @@ class ExtractMetadata(WorkTask):
         If there is any data specific split, that will already be done in
         get_all_metadata. This function is for automatic splitting if the splits
         are not found.
+
+            Note that all files are shuffled and we pick exactly as
+        many as we want for each split. Unlike using modulus of the
+        hash of the split key (Google `which_set` method), the
+        filename does not uniquely determine the split, but the
+        entire set of audio data determines the split.
+        The downside to this is that if a later version of the
+        dataset is released with more files, this method will not
+        preserve the split across dataset versions.
+            The benefit of this approach is that, for small datasets,
+        it correctly stratifies the data according to the desired
+            percentages. For small datasets, unless the splits are
+        predetermined (e.g. in a key file), using the size of the
+        data set to stratify is unavoidable. If we do want to
+        preserve splits across versions, we can create key files
+        for audio files that were in previous versions.
 
         Three cases might arise -
         1. Validation split not found - Train will be split into valid and train
@@ -289,7 +310,7 @@ class ExtractMetadata(WorkTask):
             train_percentage + valid_percentage + test_percentage == 100
         ), f"{train_percentage + valid_percentage + test_percentage} != 100"
 
-        split_keys = metadata["split_key"].unique()
+        split_keys = sorted(metadata["split_key"].unique())
         rng = random.Random("split_train_test_val")
         rng.shuffle(split_keys)
         n = len(split_keys)
@@ -307,9 +328,6 @@ class ExtractMetadata(WorkTask):
     def run(self):
         # Process metadata gets all metadata to be used for the task
         metadata = self.get_all_metadata()
-
-        # Deterministically shuffle the metadata
-        metadata = metadata.sample(frac=1, random_state=0).reset_index(drop=True)
 
         metadata = metadata.assign(
             slug=lambda df: df.relpath.apply(self.slugify_file_name),
@@ -333,6 +351,17 @@ class ExtractMetadata(WorkTask):
 
         # Assertion sanity check -- one to one mapping between the relpaths and slugs
         assert metadata["relpath"].nunique() == metadata["slug"].nunique()
+
+        # First, put the metadata into a deterministic order.
+        if "start" in metadata.columns:
+            metadata.sort_values(
+                ["slug", "start", "end", "label"], inplace=True, kind="stable"
+            )
+        else:
+            metadata.sort_values(["slug", "label"], inplace=True, kind="stable")
+
+        # Now, deterministically shuffle the metadata
+        metadata = metadata.sample(frac=1, random_state=0).reset_index(drop=True)
 
         # Filter the files which actually exist in the data
         exists = metadata["relpath"].apply(lambda relpath: Path(relpath).exists())
@@ -420,7 +449,16 @@ class SubsampleSplit(MetadataTask):
 
     def run(self):
         split_metadata = self.metadata[self.metadata["split"] == self.split]
-        relpaths = split_metadata["relpath"].unique()
+        # Deterministically sort by the slugs, then deterministically
+        # shuffle their relpaths.
+        # See get_split_key for a description of why we use slugs,
+        # not relpaths, for sorting.
+        slug_relpaths = [
+            (slug, relpath)
+            for slug, relpath in split_metadata[["slug", "relpath"]].values
+        ]
+        slug_relpaths = sorted(list(set(slug_relpaths)))
+        relpaths = [relpath for slug, relpath in slug_relpaths]
         rng = random.Random("SubsampleSplit")
         rng.shuffle(relpaths)
         num_files = len(relpaths)

--- a/hearpreprocess/pipeline.py
+++ b/hearpreprocess/pipeline.py
@@ -238,7 +238,7 @@ class ExtractMetadata(WorkTask):
         based upon the split_key (see above).
 
         If there is any data specific split, that will already be
-            done in get_all_metadata. This function is for automatic
+        done in get_all_metadata. This function is for automatic
         splitting if the splits are not found.
 
         Note that all files are shuffled and we pick exactly as
@@ -249,7 +249,7 @@ class ExtractMetadata(WorkTask):
         * The downside is that if a later version of the
         dataset is released with more files, this method will not
         preserve the split across dataset versions.
-            * The benefit is that, for small datasets, it correctly
+        * The benefit is that, for small datasets, it correctly
         stratifies the data according to the desired percentages.
         For small datasets, unless the splits are predetermined
         (e.g. in a key file), using the size of the data set to

--- a/hearpreprocess/pipeline.py
+++ b/hearpreprocess/pipeline.py
@@ -237,25 +237,25 @@ class ExtractMetadata(WorkTask):
         split if any of test or valid split is not found. We split
         based upon the split_key (see above).
 
-        If there is any data specific split, that will already be done in
-        get_all_metadata. This function is for automatic splitting if the splits
-        are not found.
+        If there is any data specific split, that will already be
+            done in get_all_metadata. This function is for automatic
+        splitting if the splits are not found.
 
-            Note that all files are shuffled and we pick exactly as
+        Note that all files are shuffled and we pick exactly as
         many as we want for each split. Unlike using modulus of the
         hash of the split key (Google `which_set` method), the
         filename does not uniquely determine the split, but the
         entire set of audio data determines the split.
-        The downside to this is that if a later version of the
+        * The downside is that if a later version of the
         dataset is released with more files, this method will not
         preserve the split across dataset versions.
-            The benefit of this approach is that, for small datasets,
-        it correctly stratifies the data according to the desired
-            percentages. For small datasets, unless the splits are
-        predetermined (e.g. in a key file), using the size of the
-        data set to stratify is unavoidable. If we do want to
-        preserve splits across versions, we can create key files
-        for audio files that were in previous versions.
+            * The benefit is that, for small datasets, it correctly
+        stratifies the data according to the desired percentages.
+        For small datasets, unless the splits are predetermined
+        (e.g. in a key file), using the size of the data set to
+        stratify is unavoidable. If we do want to preserve splits
+        across versions, we can create key files for audio files
+        that were in previous versions.
 
         Three cases might arise -
         1. Validation split not found - Train will be split into valid and train


### PR DESCRIPTION
Based upon @khumairraj 's comment in https://github.com/neuralaudio/hear-preprocess/pull/10/files/b7d06456a8918b5a25e916a3c419dd1cd79b4417#diff-cc34890a27a66ca7464f3ce758ab6b94fe835fb031e9ed47012f178c06c0dc91

* We use slugs, not relpaths, for deterministically sorting all rows prior to sampling.
* We are more careful that slugs are in a deterministic order.
* Splitting based upon the rest of the data set is unavoidable for small datasets.