### PR TITLE
Fix the audio task order for precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ to the following DAG:
 * ExtractArchive
 * ExtractMetadata: Create splits over the entire corpus and find
 the label metadata for them.
-* SubcorpusSplit (subsample each split) => MonoWavTrimCorpus => SubcorpusData (symlinks)
+* SubcorpusSplit (subsample each split) => MonoWavSubcorpus => TrimPadSubcorpus => SubcorpusData (symlinks)
 * SubcorpusData => {SubcorpusMetadata, ResampleSubcorpus}
 * SubcorpusMetadata => MetadataVocabulary
 * FinalCombine => FinalizeCorpus

--- a/hearpreprocess/pipeline.py
+++ b/hearpreprocess/pipeline.py
@@ -793,13 +793,13 @@ class SubsampleSplits(MetadataTask):
         self.mark_complete()
 
 
-class MonoWavSubCorpus(MetadataTask):
+class MonoWavSubcorpus(MetadataTask):
     """
     Converts the files to wav and mono encoding.
 
     This task ensures that the audio is converted to an uncompressed format
     so that any downstream operation on the audio
-    results in precise outputs(like trimming and padding)
+    results in precise outputs (like trimming and padding)
     https://stackoverflow.com/questions/54153364/ffmpeg-being-inprecise-when-trimming-mp3-files # noqa: E501
 
     Requires:
@@ -828,12 +828,12 @@ class TrimPadSubcorpus(MetadataTask):
     Trims and pads the wav audio files
 
     Requires:
-        corpus (MonoWavSubCorpus): task which converts the audio to wav file
+        corpus (MonoWavSubcorpus): task which converts the audio to wav file
     """
 
     def requires(self):
         return {
-            "corpus": MonoWavSubCorpus(
+            "corpus": MonoWavSubcorpus(
                 metadata_task=self.metadata_task, task_config=self.task_config
             )
         }
@@ -844,7 +844,7 @@ class TrimPadSubcorpus(MetadataTask):
             audio_util.trim_pad_wav(
                 str(audiofile),
                 str(newaudiofile),
-                out_dur=self.task_config["sample_duration"],
+                duration=self.task_config["sample_duration"],
             )
 
         self.mark_complete()

--- a/hearpreprocess/pipeline.py
+++ b/hearpreprocess/pipeline.py
@@ -793,10 +793,14 @@ class SubsampleSplits(MetadataTask):
         self.mark_complete()
 
 
-class MonoWavTrimSubcorpus(MetadataTask):
+class MonoWavSubCorpus(MetadataTask):
     """
-    Converts the file to mono, changes to wav encoding,
-    trims and pads the audio to be same length
+    Converts the files to wav and mono encoding.
+
+    This task ensures that the audio is converted to an uncompressed format
+    so that any downstream operation on the audio
+    results in precise outputs(like trimming and padding)
+    https://stackoverflow.com/questions/54153364/ffmpeg-being-inprecise-when-trimming-mp3-files # noqa: E501
 
     Requires:
         corpus (SubsampleSplits): task which aggregates all subsampled splits
@@ -814,10 +818,33 @@ class MonoWavTrimSubcorpus(MetadataTask):
             if audiofile.suffix == ".json":
                 continue
             newaudiofile = self.workdir.joinpath(f"{audiofile.stem}.wav")
-            audio_util.mono_wav_and_fix_duration(
+            audio_util.mono_wav(str(audiofile), str(newaudiofile))
+
+        self.mark_complete()
+
+
+class TrimPadSubcorpus(MetadataTask):
+    """
+    Trims and pads the wav audio files
+
+    Requires:
+        corpus (MonoWavSubCorpus): task which converts the audio to wav file
+    """
+
+    def requires(self):
+        return {
+            "corpus": MonoWavSubCorpus(
+                metadata_task=self.metadata_task, task_config=self.task_config
+            )
+        }
+
+    def run(self):
+        for audiofile in tqdm(list(self.requires()["corpus"].workdir.iterdir())):
+            newaudiofile = self.workdir.joinpath(f"{audiofile.stem}.wav")
+            audio_util.trim_pad_wav(
                 str(audiofile),
                 str(newaudiofile),
-                duration=self.task_config["sample_duration"],
+                out_dur=self.task_config["sample_duration"],
             )
 
         self.mark_complete()
@@ -828,13 +855,12 @@ class SubcorpusData(MetadataTask):
     Go over the mono wav folder and symlink the audio files into split dirs.
 
     Requires
-        corpus(MonoWavTrimSubcorpus): which processes the audio file and converts
-            them to wav format
+        corpus(TrimPadSubcorpus): Trims and pads audio to the desired duration
     """
 
     def requires(self):
         return {
-            "corpus": MonoWavTrimSubcorpus(
+            "corpus": TrimPadSubcorpus(
                 metadata_task=self.metadata_task, task_config=self.task_config
             ),
         }

--- a/hearpreprocess/util/audio.py
+++ b/hearpreprocess/util/audio.py
@@ -47,7 +47,7 @@ def trim_pad_wav(in_file: str, out_file: str, duration: float) -> None:
                 .audio.filter("apad", whole_dur=duration)  # Pad
                 .filter("atrim", end=duration)  # Trim
                 .output(out_file, f="wav", acodec="pcm_f32le", ac=1)
-                .run(quiet = True)
+                .run(quiet=True)
             )
         except ffmpeg.Error as e:
             print(
@@ -79,8 +79,7 @@ def resample_wav(in_file: str, out_file: str, out_sr: int) -> None:
                 ffmpeg.input(in_file)
                 # Use SoX high quality mode
                 .filter("aresample", resampler="soxr")
-                .output(out_file, ar=out_sr)
-                .run(quiet=True)
+                .output(out_file, ar=out_sr).run(quiet=True)
             )
         except ffmpeg.Error as e:
             print(

--- a/hearpreprocess/util/audio.py
+++ b/hearpreprocess/util/audio.py
@@ -13,72 +13,72 @@ import ffmpeg
 from tqdm import tqdm
 
 
-def mono_wav_and_fix_duration(in_file: str, out_file: str, duration: float) -> None:
-    """
-    This
-    1. Pads and trims the audio to the desired input duration
-    2. Converts to mono if more than 1 stream is present
-    3. Converts the audio to wav format
-    All the above are only done when the input file doesnot match the required
-    conditions of duration, streams and extension.
-    In case, we are unable to get any audio stats, by default all the steps are done.
-    If the audio is already satisfies all the expected filters, the step is skipped
-    and a symlink is created to the original file
-    """
-    # Get the audio stats for the audio file
-    audio_stats = get_audio_stats(in_file)
-    # Get the filters to apply to the audio.
-    # If ffmpeg probe is unable to fetch the audio stats
-    # in which case the stats will be empty
-    # we will make all the filters as True
-    if audio_stats is not None:
-        duration_filter_incorrect = audio_stats["duration"] != duration
-        mono_filter_incorrect = not audio_stats["mono"]
-    else:
-        duration_filter_incorrect = mono_filter_incorrect = True
+def mono_wav(in_file: str, out_file: str) -> None:
+    """converts the audio to wav format with mono stream"""
+    try:
+        _ = (
+            ffmpeg.input(in_file)
+            .audio.output(out_file, f="wav", acodec="pcm_f32le", ac=1)
+            .overwrite_output()
+            .run(quiet=True)
+        )
+    except ffmpeg.Error as e:
+        print(
+            "Please check the console output for ffmpeg to debug the "
+            "error in mono wav: ",
+            f"Error: {e}",
+        )
+        raise
 
-    ext_filter_incorrect = Path(in_file).suffix.lower() != ".wav"
 
-    # If the audio has the desired duration and is already mono .wav all the flags will
-    # be false, then we will move to the else part where we will just create a symlink
-    if duration_filter_incorrect or mono_filter_incorrect or ext_filter_incorrect:
-        # create a ffmpeg command chain to take the input
-        cmd_chain = ffmpeg.input(in_file).audio
-        # Add duration commands if required
-        if duration_filter_incorrect:
-            cmd_chain = cmd_chain.filter("apad", whole_dur=duration).filter(
-                "atrim", end=duration
-            )
+def trim_pad_wav(in_file: str, out_file: str, out_dur: float) -> None:
+    """
+    Trims and pads the audio to the desired output duration
+    If the audio is already of the desired duration, make a symlink
+    """
+    # If the audio is of the desired duration
+    # move to the else part where we will just create a symlink
+    if get_audio_stats(in_file)["duration"] != out_dur:
+        # Trim and pad the audio
         try:
             _ = (
-                cmd_chain.output(out_file, f="wav", acodec="pcm_f32le", ac=1)
+                ffmpeg.input(in_file)
+                .audio.filter("apad", whole_dur=out_dur)  # Pad
+                .filter("atrim", end=out_dur)  # Trim
+                .output(out_file, f="wav", acodec="pcm_f32le", ac=1)
                 .overwrite_output()
                 .run(quiet=True)
             )
         except ffmpeg.Error as e:
             print(
                 "Please check the console output for ffmpeg to debug the "
-                "error in mono wav and fix duration: ",
+                "error in trim and pad wav: ",
                 f"Error: {e}",
             )
             raise
+        # Check if the file has been converted to the desired duration
+        new_dur = get_audio_stats(out_file)["duration"]
+        assert (
+            new_dur == out_dur
+        ), f"The new file is {new_dur} secs while expected is {out_dur} secs"
     else:
-        # If the file already has the desired duration and is mono wav, make a symlink
-        assert not Path(out_file).exists()
+        assert not Path(out_file).exists(), "File already exists"
         Path(out_file).symlink_to(Path(in_file).absolute())
 
 
 def resample_wav(in_file: str, out_file: str, out_sr: int) -> None:
-    """Resample a wave file using SoX high quality mode"""
-    # Get the audio stats to get the sampling rate of the audio
-    audio_stats = get_audio_stats(in_file)
-    # If the desired sampling rate is the same as that of the original file,
-    # skip resampling and create symlink
-    if audio_stats is not None and audio_stats["sample_rate"] != out_sr:
+    """
+    Resample a wave file using SoX high quality mode
+    If the audio is already of the desired sample rate, make a symlink
+    """
+    # If the audio is of the desired sample rate
+    # move to the else part where we will just create a symlink
+    if get_audio_stats(in_file)["sample_rate"] != out_sr:
         try:
             _ = (
                 ffmpeg.input(in_file)
-                .filter("aresample", resampler="soxr")
+                # Use SoX high quality mode
+                # .filter("aresample", resampler="soxr")
                 .output(out_file, ar=out_sr)
                 .overwrite_output()
                 .run(quiet=True)
@@ -86,12 +86,17 @@ def resample_wav(in_file: str, out_file: str, out_sr: int) -> None:
         except ffmpeg.Error as e:
             print(
                 "Please check the console output for ffmpeg to debug the "
-                "error in resample_wav: ",
+                "error in resample wav: ",
                 f"Error: {e}",
             )
             raise
+        # Check if the file has been converted to the desired sampling rate
+        new_sr = get_audio_stats(out_file)["sample_rate"]
+        assert (
+            new_sr == out_sr
+        ), f"The new file is {new_sr} secs while expected is {out_sr} secs"
     else:
-        # If the audio has the expected sampling rate, make a synlink
+        # If the audio has the expected sampling rate, make a symlink
         assert not Path(out_file).exists()
         Path(out_file).symlink_to(Path(in_file).absolute())
 

--- a/hearpreprocess/util/audio.py
+++ b/hearpreprocess/util/audio.py
@@ -15,11 +15,11 @@ from tqdm import tqdm
 
 def mono_wav(in_file: str, out_file: str) -> None:
     """converts the audio to wav format with mono stream"""
+    assert not Path(out_file).exists(), "File already exists"
     try:
         _ = (
             ffmpeg.input(in_file)
             .audio.output(out_file, f="wav", acodec="pcm_f32le", ac=1)
-            .overwrite_output()
             .run(quiet=True)
         )
     except ffmpeg.Error as e:
@@ -79,7 +79,8 @@ def resample_wav(in_file: str, out_file: str, out_sr: int) -> None:
                 ffmpeg.input(in_file)
                 # Use SoX high quality mode
                 .filter("aresample", resampler="soxr")
-                .output(out_file, ar=out_sr).run(quiet=True)
+                .output(out_file, ar=out_sr)
+                .run(quiet=True)
             )
         except ffmpeg.Error as e:
             print(

--- a/hearpreprocess/util/audio.py
+++ b/hearpreprocess/util/audio.py
@@ -29,7 +29,13 @@ def mono_wav(in_file: str, out_file: str) -> None:
             f"Error: {e}",
         )
         raise
+
+    # Check if the generated file is present and that ffmpeg can
+    # read stats for the file to be used in subsequent processing steps
     assert Path(out_file).exists(), "wav file saved by ffmpeg was not found"
+    assert (
+        get_audio_stats(out_file)["ext"] is not None
+    ), "Unable to get stats for the generated wav file"
 
 
 def trim_pad_wav(in_file: str, out_file: str, duration: float) -> None:

--- a/hearpreprocess/util/audio.py
+++ b/hearpreprocess/util/audio.py
@@ -29,6 +29,7 @@ def mono_wav(in_file: str, out_file: str) -> None:
             f"Error: {e}",
         )
         raise
+    assert Path(out_file).exists(), "wav file saved by ffmpeg was not found"
 
 
 def trim_pad_wav(in_file: str, out_file: str, duration: float) -> None:


### PR DESCRIPTION
This puts audio operations in order, i.e first convert to Wav format and then do the postprocessing of trimming and padding. This ensures operations are precise since they are done in wav format audio