### PR TITLE
Parameters differ from overridden 'get_requires_metadata' method

### DIFF
--- a/hearpreprocess/dcase2016_task2.py
+++ b/hearpreprocess/dcase2016_task2.py
@@ -93,13 +93,13 @@ class ExtractMetadata(pipeline.ExtractMetadata):
         "train_eval": "train/eval/dcase2016_task2_test_public/",
     }
 
-    def get_requires_metadata(self, requires_key: str) -> pd.DataFrame:
-        logger.info(f"Preparing metadata for {requires_key}")
+    def get_requires_metadata(self, split: str) -> pd.DataFrame:
+        logger.info(f"Preparing metadata for {split}")
 
-        assert requires_key.startswith("train_")
+        assert split.startswith("train_")
 
-        requires_path = Path(self.requires()[requires_key].workdir).joinpath(
-            self.requires_key_to_path_str[requires_key]
+        requires_path = Path(self.requires()[split].workdir).joinpath(
+            self.requires_key_to_path_str[split]
         )
 
         metadatas = []

--- a/hearpreprocess/pipeline.py
+++ b/hearpreprocess/pipeline.py
@@ -288,7 +288,7 @@ class ExtractMetadata(WorkTask):
         """
         return df["unique_filestem"]
 
-    def get_requires_metadata(self, requires_key: str) -> pd.DataFrame:
+    def get_requires_metadata(self, split: str) -> pd.DataFrame:
         """
         For a particular key in the task requires (e.g. "train", or "train_eval"),
         return a metadata dataframe with the following columns (see above):


### PR DESCRIPTION
Fixed the violation of Liskov substitution principle by *get_requires_metadata* method as per deepsource issue : https://deepsource.io/gh/neuralaudio/hear-preprocess/issue/PYL-W0221/occurrences