### PR TITLE
Fix the metadata to be of type string

### DIFF
--- a/hearpreprocess/pipeline.py
+++ b/hearpreprocess/pipeline.py
@@ -682,7 +682,7 @@ class MetadataTask(WorkTask):
         if self._metadata is None:
             self._metadata = pd.read_csv(
                 self.metadata_task.workdir.joinpath(self.metadata_task.outfile)
-            )
+            ).astype(str)
         return self._metadata
 
 


### PR DESCRIPTION
The metadata columns should all be interpreted as string while reading the pandas `metadata` dataframe.